### PR TITLE
wrapper class call Dispose on wrappedObject

### DIFF
--- a/dotnet4/wrapper.cs
+++ b/dotnet4/wrapper.cs
@@ -23,7 +23,11 @@ namespace jxshell.dotnet4
 
         public virtual void dispose()
         {
-            wrappedObject = null;
+			if (!(wrappedObject is null) && (wrappedObject is IDisposable))
+			{
+				((IDisposable)wrappedObject).Dispose();
+			}
+			wrappedObject = null;
             wrappedType = null;
             typeD = null;
         }


### PR DESCRIPTION
If wrappedObject is an IDisposable, call the Dispose method on it to avoid problems.